### PR TITLE
Removed minor version pinning of Perfect-HTTP

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,5 +26,5 @@ let urls = [
 let package = Package(
     name: "PerfectWebSockets",
     targets: [],
-    dependencies: urls.map { .Package(url: $0, majorVersion: 2, minor: 0) }
+    dependencies: urls.map { .Package(url: $0, majorVersion: 2) }
 )


### PR DESCRIPTION
Perfect-HTTPServer and Perfect-WebSockets have different version requirements to Perfect-HTTP (2.1.* vs 2.0.*). If both Packages are used in the same project a dependency error occurs:

error: The dependency graph could not be satisfied (https://github.com/PerfectlySoft/Perfect-HTTP.git)

This can be fixed by removing the minor version pinning to Perfect-HTTP from Perfect-WebSockets.